### PR TITLE
Refactoring the CSV Importer Files

### DIFF
--- a/k8s/geocoder/data-importers/csv-import/csv-importer.yaml
+++ b/k8s/geocoder/data-importers/csv-import/csv-importer.yaml
@@ -4,30 +4,43 @@ metadata:
   name: csv-importer
   namespace: geocoder
 spec:
-  backoffLimit: 0 
+  backoffLimit: 0
   template:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      initContainers:
+      - name: fetch-files
+        image: google/cloud-sdk:latest
+        command: ["/bin/sh", "-c"]
+        args:
+          - |
+            # Find the latest CSV file in the bucket
+            LATEST_FILE=$(gsutil ls gs://pelias-bucket | sort | tail -n 1)
+            # Copy the latest CSV file to the shared volume
+            gsutil cp ${LATEST_FILE} /data/csv-importer-files/
+        volumeMounts:
+          - name: data-volume
+            mountPath: /data
       containers:
-        - name: csv-importer-cnt
-          image: pelias/csv-importer:v3.0.0
-          command: ["./bin/start"]
-          volumeMounts:
-            - name: data-volume
-              mountPath: /data
-            - name: config-volume
-              mountPath: /code/pelias.json
-              subPath: pelias.json
+      - name: csv-importer-cnt
+        image: pelias/csv-importer:v3.0.0
+        command: ["./bin/start"]
+        volumeMounts:
+          - name: data-volume
+            mountPath: /data
+          - name: config-volume
+            mountPath: /code
+            subPath: pelias.json
       restartPolicy: Never
       securityContext:
         fsGroup: 1000
       volumes:
-        - name: data-volume
+      - name: data-volume
           persistentVolumeClaim:
             claimName: data-volume
-        - name: config-volume
-          configMap:
-            name: pelias-configmap
-
+      - name: config-volume
+        configMap:
+          name: pelias-configmap
+      serviceAccountName: pelias-bucket-access


### PR DESCRIPTION
The init container is used to fetch the latest files from the GCP bucket and loads it into the volume for the container to process. 

Please test the job thoroughly 