### PR TITLE
chore(ui): a11y - change top nav from custom to gcds design. Legacy c…

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,13 +1,22 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Pelias-Geocoder</title>
-  </head>
-  <body>
-    <div id="react-root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<link rel="icon" type="image/svg+xml" href="https://www.canada.ca/etc/designs/canada/wet-boew/assets/favicon.ico" />
+
+		<!-- Icons Font Awesome (to access icons, import Font Awesome) -->
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" crossorigin="anonymous" />
+
+		<!-- GC Design System -->
+		<link rel="stylesheet" href="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.css" />
+		<script type="module" src="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.esm.js"></script>
+		<script nomodule src="/node_modules/@cdssnc/gcds-components/dist/gcds/gcds.js"></script>
+
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Pelias-Geocoder</title>
+	</head>
+	<body>
+		<div id="react-root"></div>
+		<script type="module" src="/src/main.jsx"></script>
+	</body>
 </html>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "ui",
 			"version": "0.1.0",
 			"dependencies": {
-				"@cdssnc/gcds-components-react": "^0.22.1",
+				"@cdssnc/gcds-components": "^0.26.3",
+				"@cdssnc/gcds-components-react": "^0.22.4",
 				"crypto-js": "^4.2.0",
 				"exceljs": "^4.4.0",
 				"file-saver": "^2.0.5",
@@ -2057,11 +2058,12 @@
 			}
 		},
 		"node_modules/@cdssnc/gcds-components": {
-			"version": "0.22.4",
-			"resolved": "https://registry.npmjs.org/@cdssnc/gcds-components/-/gcds-components-0.22.4.tgz",
-			"integrity": "sha512-AYL/cTlpxnCcD4fsBSqcNN1b84vjuGPRoysRap1aXwfTExuyR2uv4FpxgThxxPNk0x9bDEi4mfdVdf/IYl3ehQ==",
+			"version": "0.26.3",
+			"resolved": "https://registry.npmjs.org/@cdssnc/gcds-components/-/gcds-components-0.26.3.tgz",
+			"integrity": "sha512-2adbqONSCgwmbmK8hw7ZyYjl9//1Kn6f6WZ2i2jrBnFn9Mcbb7gckIyi7dlIogRLUL6itxmHRKMZFBdOFjDqkg==",
+			"license": "MIT",
 			"dependencies": {
-				"@stencil/core": "^4.11.0",
+				"@stencil/core": "4.19.2",
 				"@stencil/react-output-target": "^0.5.3",
 				"@storybook/addon-a11y": "^8.0.9",
 				"@storybook/addons": "^7.6.17",
@@ -2075,6 +2077,33 @@
 			"integrity": "sha512-KP0MQ7qRUJesok4WxhF4wgHY8YIe1dcSBxNNe5PTftKda3cPtcTnADdRdpp8Hf+7fnruLcaVDxu1X2BTvildFQ==",
 			"dependencies": {
 				"@cdssnc/gcds-components": "^0.22.4"
+			}
+		},
+		"node_modules/@cdssnc/gcds-components-react/node_modules/@cdssnc/gcds-components": {
+			"version": "0.22.4",
+			"resolved": "https://registry.npmjs.org/@cdssnc/gcds-components/-/gcds-components-0.22.4.tgz",
+			"integrity": "sha512-AYL/cTlpxnCcD4fsBSqcNN1b84vjuGPRoysRap1aXwfTExuyR2uv4FpxgThxxPNk0x9bDEi4mfdVdf/IYl3ehQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@stencil/core": "^4.11.0",
+				"@stencil/react-output-target": "^0.5.3",
+				"@storybook/addon-a11y": "^8.0.9",
+				"@storybook/addons": "^7.6.17",
+				"@storybook/test": "^8.0.9",
+				"@storybook/theming": "^8.0.9"
+			}
+		},
+		"node_modules/@cdssnc/gcds-components/node_modules/@stencil/core": {
+			"version": "4.19.2",
+			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.19.2.tgz",
+			"integrity": "sha512-ZdnbHmHEl8E5vN0GWDtONe5w6j3CrSqqxZM4hNLBPkV/aouWKug7D5/Mi6RazfYO5U4fmHQYLwMz60rHcx0G4g==",
+			"license": "MIT",
+			"bin": {
+				"stencil": "bin/stencil"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=7.10.0"
 			}
 		},
 		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@cdssnc/gcds-components-react": "^0.22.1",
+		"@cdssnc/gcds-components": "^0.26.3",
+		"@cdssnc/gcds-components-react": "^0.22.4",
 		"crypto-js": "^4.2.0",
 		"exceljs": "^4.4.0",
 		"file-saver": "^2.0.5",

--- a/frontend/src/layout/Layout.css
+++ b/frontend/src/layout/Layout.css
@@ -1,54 +1,19 @@
 .skip-to-content-link {
-  height: 30px;
-  left: 50%;
-  padding: 8px;
   position: absolute;
-  transform: translateY(-100%);
+  transform: translate(-50%, -1000%);  
   transition: transform 0.3s;
+  background-color: rgb(38, 55, 74);
+  color: rgb(255, 255, 255);
+  font-size: 16px;
+  font-weight: 700;
+  padding: 5px;
+  text-align: center;
+  z-index: -1; /* Keeps it out of focus when not focused */
 }
 
 .skip-to-content-link:focus {
-  transform: translateY(0%);
+  top: 10px; 
+  transform: translate(-50%, 0%); /* Moves it on-screen  */
+  z-index: 501; /* Brings it to the front */
 }
 
-
-.breadcrumb {
-  display: flex;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.breadcrumb-item + .breadcrumb-item::before {
-  content: '>';
-  padding: 0 0.5rem;
-}
-
-.breadcrumb-item a {
-  color: black;
-  text-decoration: none;
-}
-
-.breadcrumb-item a:hover {
-  color: blue;
-  text-decoration: underline;
-  font-weight: bold;
-}
-
-.astext {
-  background:none;
-  border:none;
-  margin:0;
-  padding:0;
-  cursor: pointer;
-  color: rgb(0, 0, 255);
-}
-.astext:hover{
-background:none;
-border:none;
-margin:0;
-padding:0;
-cursor: pointer;
-color: rgb(0,0,200);
-text-decoration: underline;
-}

--- a/frontend/src/layout/Layout.jsx
+++ b/frontend/src/layout/Layout.jsx
@@ -1,18 +1,13 @@
 import { Outlet, useLocation } from "react-router-dom"
-import { GcdsHeader, GcdsContainer, GcdsFooter } from "@cdssnc/gcds-components-react"
+import { GcdsHeader, GcdsContainer, GcdsFooter, GcdsTopNav, GcdsNavLink, GcdsNavGroup, GcdsLangToggle, GcdsBreadcrumbsItem, GcdsBreadcrumbs } from "@cdssnc/gcds-components-react"
 import "@cdssnc/gcds-components-react/gcds.css"
-import Breadcrumb from "../components/Breadcrumb"
 import "./Layout.css"
-import TopNav from "./TopNav"
 import { useTranslation } from "react-i18next"
+import { useState } from "react"
 
 export default function Layout() {
 	const { t, i18n } = useTranslation()
-
-	const changeLanguage = lng => {
-		i18n.changeLanguage(lng)
-	}
-
+	const [announcement, setAnnouncement] = useState("") // State for announcements
 	const location = useLocation()
 
 	const contextualLinks = {
@@ -20,50 +15,97 @@ export default function Layout() {
 		[t("footer.faq")]: "/frequently-asked-questions",
 	}
 
+	const changeLanguage = lng => {
+		i18n.changeLanguage(lng)
+		setAnnouncement(`${lng === "fr" ? "La langue a été changée en français" : "The language has been changed to English"}`) // Update announcement
+	}
+
 	return (
 		<>
-			<GcdsHeader skipToHref="#main-content" padding="150px" height="auto" lang={i18n.language}>
-				<div slot="toggle">
-					{i18n.language === "en" ? (
-						<button className="astext" onClick={() => changeLanguage("fr")}>
-							French
-						</button>
-					) : (
-						<button className="astext" onClick={() => changeLanguage("en")}>
-							English
-						</button>
+			<GcdsHeader langHref={i18n.language} signatureHasLink="false" lang={i18n.language}>
+				<div slot="menu">
+					<GcdsTopNav label="Top navigation" alignment="right">
+						<GcdsNavLink href="/" slot="home">
+							Pelias
+						</GcdsNavLink>
+						<GcdsNavGroup openTrigger={t("menu.bulkFile")} menuLabel={t("menu.bulkFile")}>
+							<GcdsNavLink href="/reverse-bulk-files" current={location.pathname === "/reverse-bulk-files" ? true : undefined}>
+								{t("menu.reverseBulkFile")}
+							</GcdsNavLink>
+							<GcdsNavLink href="/forward-bulk-files" current={location.pathname === "/forward-bulk-files" ? true : undefined}>
+								{t("menu.addressBulkFile")}
+							</GcdsNavLink>
+						</GcdsNavGroup>
+						<GcdsNavGroup openTrigger={t("menu.developers")} menuLabel={t("menu.developers")}>
+							<GcdsNavLink href="/r-api" current={location.pathname === "/r-api" ? true : undefined}>
+								R Api
+							</GcdsNavLink>
+							<GcdsNavLink href="/python-api" current={location.pathname === "/python-api" ? true : undefined}>
+								Python Api
+							</GcdsNavLink>
+						</GcdsNavGroup>
+						<GcdsNavLink href="/contact-us" current={location.pathname === "/contact-us" ? true : undefined}>
+							{t("menu.contactUs")}
+						</GcdsNavLink>
+					</GcdsTopNav>
+				</div>
+				<div slot="breadcrumb">
+					{location.pathname === "/" ? null : (
+						<GcdsBreadcrumbs>
+							<GcdsBreadcrumbsItem href="/">Pelias</GcdsBreadcrumbsItem>
+						</GcdsBreadcrumbs>
 					)}
 				</div>
-				<div slot="skip-to-nav">
+				<div slot="skip-to-nav" style={{ textAlign: "center", top: "10px", left: 0, width: "100%", zIndex: 3 }}>
 					<a className="skip-to-content-link" href="#main-content">
-						Skip to main content
+						Skip to main content / Passer au contenu principal
 					</a>
 				</div>
-				<nav slot="menu" style={{ backgroundColor: "#f1f2f3" }}>
-					<GcdsContainer size="xl" centered color="black">
-						<TopNav />
-					</GcdsContainer>
-				</nav>
+				<div slot="toggle">
+					<GcdsLangToggle
+						href="#"
+						lang={i18n.language}
+						onClick={event => {
+							event.preventDefault()
+							changeLanguage(i18n.language === "en" ? "fr" : "en")
+						}}
+					></GcdsLangToggle>
+				</div>
 			</GcdsHeader>
+
 			<GcdsContainer
-				size={location.pathname === "/home" || location.pathname === "/" ? "full" : "xl" || "lg"}
+				size={location.pathname === "/home" || location.pathname === "/" ? "full" : "xl"}
 				centered
 				color="black"
-				style={{
-					flexGrow: "1",
-				}}
-				padding="400"
+				style={{ flexGrow: "1" }}
+				main-container
 				id="main-content"
 			>
-				<Breadcrumb />
 				<Outlet />
+				<GcdsTopNav
+  label="Top navigation"
+  alignment="right"
+>
+  <GcdsNavLink href="#home" slot="home">GC Notify</GcdsNavLink> 
+  <GcdsNavLink href="#">Why GC Notify</GcdsNavLink>
+
+  <GcdsNavGroup  openTrigger="Features" menuLabel="Features">
+    <GcdsNavLink href="#" current>Create reusable templates</GcdsNavLink>
+    <GcdsNavLink href="#">Personalize messages</GcdsNavLink>
+    <GcdsNavLink href="#">Schedule messages</GcdsNavLink>
+    <GcdsNavLink href="#">Send messages automatically</GcdsNavLink>
+  </GcdsNavGroup>
+
+  <GcdsNavLink href="#">Contact us</GcdsNavLink>
+</GcdsTopNav>
 			</GcdsContainer>
-			<GcdsFooter
-				lang={i18n.language}
-				display="full"				
-				contextualHeading={t("footer.additionalNav")}
-				contextualLinks={contextualLinks} // Pass the object here
-			/>
+
+			{/* Announce the language change */}
+			<span aria-live="polite" style={{ position: "absolute", left: "-9999px", width: "1px", height: "1px", overflow: "hidden" }}>
+				{announcement}
+			</span>
+
+			<GcdsFooter lang={i18n.language} display="full" contextualHeading={t("footer.additionalNav")} contextualLinks={contextualLinks} style={{paddingTop:"50px"}}/>
 		</>
 	)
 }


### PR DESCRIPTION
…omponent transferred from pre-alpha version.

Due to the nature of the pre alpha build of the Pelias Geocoder, the project was built and hosted on GitHub Pages. This resulted in top nav being a custom component to meet the needs of the hosting service. Legacy Component has been converted into the GCDS design Alpha <GcdsTopNav> and utilizes the approved component. 

GCDS component addresses multiple issues for accessibility, and the translation of aria-labels. The follow push closes : 
#188  
#189 
#195 
#197 
#199 
#209 
#210 
#213 
#214 
#235 
#236 
#237 
#238 
#239
#241
#284 