### PR TITLE
fix: changed machine type to e2 highcpu 8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,3 +48,4 @@ steps:
 
 options:
   defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+  machineType: "E2_HIGHCPU_8"

--- a/frontend/cloudbuild.yaml
+++ b/frontend/cloudbuild.yaml
@@ -109,3 +109,5 @@ steps:
         else
           exit 0
         fi
+options:
+  machineType: "E2_HIGHCPU_8"


### PR DESCRIPTION
Changed the root and frontend cloudbuilds to include e2_highcpu_8 machine type to the options in hopes that it will speed up the spin. leaving the unit and e2e tests for accessibility scan and the vulnerability cloud function deployment cloudbuilds for now as they will only be run when there are changes to those directories. 